### PR TITLE
Update Google Calendar export link

### DIFF
--- a/app/my-calendars/page.tsx
+++ b/app/my-calendars/page.tsx
@@ -227,13 +227,13 @@ export default function MyCalendarsPage() {
         baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://upv-cal.vercel.app';
       }
       
-      // For Google Calendar, use a direct iCal URL like UPV's working example
-      // This will open Google Calendar's "Add calendar from URL" dialog with our URL pre-filled
+      // For Google Calendar, construct a direct iCal URL
+      // This will open Google Calendar's "Add calendar?" dialog with our URL pre-filled
       const icalUrl = `${baseUrl}/api/ical?name=${encodeURIComponent(calendar.name)}`
       
-      // Use Google Calendar's direct subscription URL - this opens the add calendar dialog
-      // with the URL pre-filled, user just needs to click "Add calendar"
-      const googleCalendarUrl = `https://calendar.google.com/calendar/u/0/r/settings/addbyurl?url=${encodeURIComponent(icalUrl)}`
+      // Use Google Calendar's direct subscription URL - this opens the dialog
+      // with the URL pre-filled so the user can simply click "Add"
+      const googleCalendarUrl = `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(icalUrl)}`
       
       // Open Google Calendar in a new tab
       window.open(googleCalendarUrl, '_blank')

--- a/app/test-ical/page.tsx
+++ b/app/test-ical/page.tsx
@@ -48,8 +48,8 @@ export default function TestICalPage() {
 
   const googleCalendarUrls = [
     {
-      name: "Method 1: settings/addbyurl (current - like UPV)",
-      url: `https://calendar.google.com/calendar/u/0/r/settings/addbyurl?url=${encodeURIComponent(
+      name: "Method 1: render?cid (recommended)",
+      url: `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(
         "https://upv-cal.vercel.app/api/ical?name=UPV%20Exams"
       )}`,
     },

--- a/components/calendar-display.tsx
+++ b/components/calendar-display.tsx
@@ -331,7 +331,8 @@ export function CalendarDisplay({ activeFilters = {} }: { activeFilters?: Record
                   return;
                 }
                 // Google Calendar subscription link
-                const googleCalendarUrl = `https://calendar.google.com/calendar/u/0/r/settings/addbyurl?url=${encodeURIComponent(icalUrl)}`;
+                // Opens Google Calendar's "Add calendar?" dialog
+                const googleCalendarUrl = `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(icalUrl)}`;
                 window.open(googleCalendarUrl, '_blank');
               }}
             >
@@ -431,7 +432,8 @@ export function CalendarDisplay({ activeFilters = {} }: { activeFilters?: Record
                     });
                     return;
                   }
-                  const googleCalendarUrl = `https://calendar.google.com/calendar/u/0/r/settings/addbyurl?url=${encodeURIComponent(icalUrl)}`;
+                  // Opens Google Calendar's "Add calendar?" dialog
+                  const googleCalendarUrl = `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(icalUrl)}`;
                   window.open(googleCalendarUrl, '_blank');
                 }}
               >

--- a/ics.md
+++ b/ics.md
@@ -109,7 +109,7 @@ The returned file is validated and delivered with proper headers.
 
 const icalUrl = `${baseUrl}/api/calendars/${calendar.id}/ical`;
 const encodedUrl = encodeURIComponent(icalUrl);
-const googleCalendarUrl = `https://calendar.google.com/calendar/r/addbyurl?url=${encodedUrl}`;
+const googleCalendarUrl = `https://calendar.google.com/calendar/render?cid=${encodedUrl}`;
 window.open(googleCalendarUrl, '\_blank');
 
 4. Issues found


### PR DESCRIPTION
## Summary
- update Google Calendar export URL to `render?cid`
- adjust comments accordingly
- keep docs and test pages in sync with new URL

## Testing
- `npm test` *(fails: iCalendar Diagnostics test)*

------
https://chatgpt.com/codex/tasks/task_e_68814e62d0f8832b91e3427f8c70e66f