### PR TITLE
fix iCal URL encoding

### DIFF
--- a/app/my-calendars/page.tsx
+++ b/app/my-calendars/page.tsx
@@ -229,7 +229,7 @@ export default function MyCalendarsPage() {
       
       // For Google Calendar, construct a direct iCal URL
       // This will open Google Calendar's "Add calendar?" dialog with our URL pre-filled
-      const icalUrl = `${baseUrl}/api/ical?name=${encodeURIComponent(calendar.name)}`
+      const icalUrl = `${baseUrl}/api/ical?name=${calendar.name}`
       
       // Use Google Calendar's direct subscription URL - this opens the dialog
       // with the URL pre-filled so the user can simply click "Add"

--- a/app/test-ical/page.tsx
+++ b/app/test-ical/page.tsx
@@ -13,7 +13,7 @@ export default function TestICalPage() {
     setLoading(true);
     try {
       const baseUrl = window.location.origin;
-      const icalUrl = `${baseUrl}/api/ical?name=UPV%20Exams`;
+      const icalUrl = `${baseUrl}/api/ical?name=UPV Exams`;
 
       console.log("🧪 Testing iCal endpoint:", icalUrl);
 
@@ -50,13 +50,13 @@ export default function TestICalPage() {
     {
       name: "Method 1: render?cid (recommended)",
       url: `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(
-        "https://upv-cal.vercel.app/api/ical?name=UPV%20Exams"
+        "https://upv-cal.vercel.app/api/ical?name=UPV Exams"
       )}`,
     },
     {
       name: "Method 2: addbyurl (legacy)",
       url: `https://calendar.google.com/calendar/r/addbyurl?url=${encodeURIComponent(
-        "https://upv-cal.vercel.app/api/ical?name=UPV%20Exams"
+        "https://upv-cal.vercel.app/api/ical?name=UPV Exams"
       )}`,
     },
     {
@@ -207,7 +207,7 @@ export default function TestICalPage() {
                 <li>
                   Paste this URL:{" "}
                   <code className="bg-gray-100 px-1 rounded">
-                    https://upv-cal.vercel.app/api/ical?name=UPV%20Exams
+                    https://upv-cal.vercel.app/api/ical?name=UPV Exams
                   </code>
                 </li>
                 <li>Click "Add calendar"</li>
@@ -216,14 +216,14 @@ export default function TestICalPage() {
 
             <div className="flex items-center gap-2">
               <code className="flex-1 p-2 bg-gray-100 rounded text-sm">
-                https://upv-cal.vercel.app/api/ical?name=UPV%20Exams
+                https://upv-cal.vercel.app/api/ical?name=UPV Exams
               </code>
               <Button
                 size="sm"
                 variant="outline"
                 onClick={() =>
                   copyToClipboard(
-                    "https://upv-cal.vercel.app/api/ical?name=UPV%20Exams"
+                    "https://upv-cal.vercel.app/api/ical?name=UPV Exams"
                   )
                 }
               >
@@ -243,7 +243,7 @@ export default function TestICalPage() {
               onClick={() => {
                 const link = document.createElement("a");
                 link.href =
-                  "https://upv-cal.vercel.app/api/ical?name=UPV%20Exams";
+                  "https://upv-cal.vercel.app/api/ical?name=UPV Exams";
                 link.download = "upv-exams.ics";
                 link.click();
               }}

--- a/components/calendar-display.tsx
+++ b/components/calendar-display.tsx
@@ -309,7 +309,7 @@ export function CalendarDisplay({ activeFilters = {} }: { activeFilters?: Record
                   return;
                 }
                 // Only use ?name=... for Google Calendar (no filters)
-                const icalUrl = `${baseUrl}/api/ical?name=${encodeURIComponent('UPV Exams')}`;
+                const icalUrl = `${baseUrl}/api/ical?name=UPV Exams`;
                 // Validate iCal URL before opening Google Calendar
                 try {
                   const response = await fetch(icalUrl);
@@ -412,7 +412,7 @@ export function CalendarDisplay({ activeFilters = {} }: { activeFilters?: Record
                     });
                     return;
                   }
-                  const icalUrl = `${baseUrl}/api/ical?name=${encodeURIComponent('UPV Exams')}`;
+                  const icalUrl = `${baseUrl}/api/ical?name=UPV Exams`;
                   try {
                     const response = await fetch(icalUrl);
                     const content = await response.text();

--- a/ics.md
+++ b/ics.md
@@ -108,9 +108,8 @@ The returned file is validated and delivered with proper headers.
    On the client side, pages like my-calendars/page.tsx craft Google Calendar URLs using the API route and open them in a new tab. Apple Calendar is triggered via the webcal: protocol.
 
 const icalUrl = `${baseUrl}/api/calendars/${calendar.id}/ical`;
-const encodedUrl = encodeURIComponent(icalUrl);
-const googleCalendarUrl = `https://calendar.google.com/calendar/render?cid=${encodedUrl}`;
-window.open(googleCalendarUrl, '\_blank');
+const googleCalendarUrl = `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(icalUrl)}`;
+window.open(googleCalendarUrl, '_blank');
 
 4. Issues found
    Unresolved merge conflicts.


### PR DESCRIPTION
## Summary
- avoid encoding calendar name when building iCal URL
- only encode the full iCal URL for Google Calendar export
- document the updated approach
- update test-ical page examples

## Testing
- `npm test` *(fails: iCalendar Diagnostics › Real-world Edge Cases › should handle empty exam list)*

------
https://chatgpt.com/codex/tasks/task_e_688157c992c4832bbc6bf3a82a14f78e